### PR TITLE
fix: mobile-zoom-input-focus 

### DIFF
--- a/components/common/SearchBar.tsx
+++ b/components/common/SearchBar.tsx
@@ -7,6 +7,7 @@ import { X } from "lucide-react";
 import { CARS_SEARCH_PARAMS } from "@/shared/constants";
 
 import { Button } from "../ui/button";
+import { Input } from "../ui/input";
 
 export default function SearchBar() {
   const router = useRouter();
@@ -17,7 +18,6 @@ export default function SearchBar() {
     searchParams.get(CARS_SEARCH_PARAMS.search) || ""
   );
 
-  // Quand les searchParams changent (ex: reset), on met à jour l'input
   useEffect(() => {
     setSearchTerm(searchParams.get(CARS_SEARCH_PARAMS.search) || "");
   }, [searchParams]);
@@ -52,22 +52,22 @@ export default function SearchBar() {
         <label htmlFor="search" className="sr-only">
           Rechercher une voiture
         </label>
-        <input
+        <Input
           id="search"
           type="text"
-          placeholder="Rechercher par marque ou modèle..."
+          placeholder="Rechercher par marque ou modèle"
+          className="placeholder:text-xs sm:placeholder:text-sm md:placeholder:text-base"
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
-          className="w-full rounded-md border px-4 py-2 pr-10 text-sm focus:outline-none focus:ring focus:ring-primary/50"
           autoComplete="off"
         />
 
         {searchTerm && (
           <Button
             type="button"
-            variant="ghost"
+            variant="link"
             onClick={clearSearch}
-            className="absolute inset-y-0 right-3 flex items-center text-gray-400 hover:text-gray-600 focus:outline-none"
+            className="absolute inset-y-0 right-3 flex items-center text-gray-400 hover:text-red-600 focus:outline-none"
             aria-label="Effacer la recherche"
           >
             <X size={18} />

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }


### PR DESCRIPTION
replace native input with custom Input component

Replace the native HTML input element with the custom Input component to ensure consistent styling and behavior across the application. Additionally, update the Button variant and hover color for better visual feedback.